### PR TITLE
endpoint POST /weets to create a weet

### DIFF
--- a/app/controllers/weets.js
+++ b/app/controllers/weets.js
@@ -1,0 +1,13 @@
+const weetsService = require('../services/weets');
+const weetsSerializer = require('../serializers/weets');
+
+exports.createWeet = async ({ user: { id: userId } }, res, next) => {
+  try {
+    const weetContent = await weetsService.getExternalWeet();
+    const createdWeet = await weetsService.createWeet(userId, weetContent);
+
+    return res.status(201).send(weetsSerializer.serializeWeet(createdWeet));
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/app/helpers/http.js
+++ b/app/helpers/http.js
@@ -1,0 +1,3 @@
+const axios = require('axios');
+
+exports.get = (uri, params) => axios.get(uri, { params }).then(({ data }) => data);

--- a/app/middlewares/validationSchemas/pagination.js
+++ b/app/middlewares/validationSchemas/pagination.js
@@ -1,0 +1,18 @@
+const { errorMessages } = require('../../constants');
+
+exports.paginationQuerySchema = {
+  size: {
+    in: 'query',
+    optional: true,
+    isInt: true,
+    toInt: true,
+    errorMessage: errorMessages.integer
+  },
+  page: {
+    in: 'query',
+    optional: true,
+    isInt: true,
+    toInt: true,
+    errorMessage: errorMessages.integer
+  }
+};

--- a/app/middlewares/validationSchemas/users.js
+++ b/app/middlewares/validationSchemas/users.js
@@ -72,20 +72,3 @@ exports.signInSchema = {
     errorMessage: errorMessages.providedAndNotEmpty
   }
 };
-
-exports.getUsersSchema = {
-  size: {
-    in: 'query',
-    optional: true,
-    isInt: true,
-    toInt: true,
-    errorMessage: errorMessages.integer
-  },
-  page: {
-    in: 'query',
-    optional: true,
-    isInt: true,
-    toInt: true,
-    errorMessage: errorMessages.integer
-  }
-};

--- a/app/models/weet.js
+++ b/app/models/weet.js
@@ -17,7 +17,8 @@ module.exports = (sequelize, DataTypes) => {
     },
     {
       tableName: 'weets',
-      underscored: true
+      underscored: true,
+      updatedAt: false
     }
   );
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,15 +2,16 @@ const { healthCheck } = require('./controllers/healthCheck');
 const { validateSchema } = require('./middlewares/schemas');
 const { authUser } = require('./middlewares/authentication');
 const usersController = require('./controllers/users');
+const weetsController = require('./controllers/weets');
+const { paginationQuerySchema } = require('./middlewares/validationSchemas/pagination');
 const {
   createUserSchema,
   signInSchema,
-  getUsersSchema,
   upsertAdminSchema
 } = require('./middlewares/validationSchemas/users');
 const {
   roles: {
-    codes: { admin }
+    codes: { admin, reg }
   }
 } = require('./constants');
 
@@ -18,6 +19,7 @@ exports.init = app => {
   app.get('/health', healthCheck);
   app.post('/users', validateSchema(createUserSchema), usersController.createUser);
   app.post('/users/sessions', validateSchema(signInSchema), usersController.signIn);
-  app.get('/users', authUser(), validateSchema(getUsersSchema), usersController.getUsers);
+  app.get('/users', authUser(), validateSchema(paginationQuerySchema), usersController.getUsers);
   app.post('/admin/users', authUser([admin]), validateSchema(upsertAdminSchema), usersController.upsertAdmin);
+  app.post('/weets', authUser([reg]), weetsController.createWeet);
 };

--- a/app/serializers/weets.js
+++ b/app/serializers/weets.js
@@ -1,0 +1,10 @@
+exports.serializeWeet = weet => {
+  const { createdAt, updatedAt, userId, ...restWeet } = weet;
+
+  return {
+    created_at: createdAt,
+    updated_at: updatedAt,
+    user_id: userId,
+    ...restWeet
+  };
+};

--- a/app/services/weets.js
+++ b/app/services/weets.js
@@ -1,6 +1,6 @@
-const axios = require('axios');
-
-const { badGatewayError } = require('../errors');
+const httpHelper = require('../helpers/http');
+const { weet: weetModel } = require('../models');
+const { badGatewayError, databaseError } = require('../errors');
 const {
   common: {
     services: { weetsBaseUrl }
@@ -8,9 +8,22 @@ const {
 } = require('../../config');
 const logger = require('../logger');
 
-exports.getWeet = () =>
-  axios.get(weetsBaseUrl, { params: { format: 'json' } }).catch(error => {
-    logger.error(error);
+exports.getExternalWeet = () =>
+  httpHelper
+    .get(weetsBaseUrl, { format: 'json' })
+    .then(({ joke }) => joke)
+    .catch(error => {
+      logger.error(error);
 
-    throw badGatewayError('An error ocurred while trying to get the weet');
-  });
+      throw badGatewayError('An error ocurred while trying to get the weet');
+    });
+
+exports.createWeet = (userId, content) =>
+  weetModel
+    .create({ content, userId })
+    .then(createdWeet => createdWeet.toJSON())
+    .catch(error => {
+      logger.error(error);
+
+      throw databaseError('An error ocurred while trying to create weet');
+    });

--- a/test/data/weets.js
+++ b/test/data/weets.js
@@ -1,0 +1,6 @@
+exports.joke =
+  'MacGyver immediately tried to make a bomb out of some Q-Tips and Gatorade, but Chuck Norris roundhouse-kicked him in the solar plexus. MacGyver promptly threw up his own heart.';
+
+exports.expectedCreatedWeet = {
+  content: exports.joke
+};

--- a/test/integration/users/getUsers.test.js
+++ b/test/integration/users/getUsers.test.js
@@ -17,7 +17,7 @@ const signInPath = '/users/sessions';
 
 describe('Get users GET /users', () => {
   let token = '';
-  let regRoleId = '';
+  let regRoleId = 0;
 
   beforeEach(async () => {
     ({ id: regRoleId } = await factory.create('role', rolesTestData.regRole));

--- a/test/integration/weets/weets.test.js
+++ b/test/integration/weets/weets.test.js
@@ -1,0 +1,114 @@
+const supertest = require('supertest');
+const { factory } = require('factory-girl');
+const axios = require('axios');
+const _ = require('lodash');
+
+const rolesTestData = require('../../data/roles');
+const usersTestData = require('../../data/users');
+const weetsTestData = require('../../data/weets');
+const app = require('../../../app');
+
+jest.mock('axios');
+
+const defaultHeaders = ['Accept', 'application/json'];
+const timeStamps = ['created_at', 'updated_at'];
+
+describe('Weets test', () => {
+  let body = {};
+  let status = 0;
+
+  describe('Creates weets', () => {
+    let token = '';
+    let regRoleId = 0;
+    let userId = 0;
+    const signInPath = '/users/sessions';
+    const weetsPath = '/weets';
+
+    describe('Create weets POST  /weets', () => {
+      beforeEach(async () => {
+        axios.get.mockImplementation(() =>
+          Promise.resolve({ status: 200, data: { joke: weetsTestData.joke } })
+        );
+        ({ id: regRoleId } = await factory.create('role', rolesTestData.regRole));
+        ({ id: userId } = await factory.create('user', { ...usersTestData.user, roleId: regRoleId }));
+        ({
+          body: { token }
+        } = await supertest(app)
+          .post(signInPath)
+          .set(...defaultHeaders)
+          .send(usersTestData.signInRequestBody));
+      });
+
+      describe('Should work correctly with satisfactory case', () => {
+        beforeEach(async () => {
+          ({ body, status } = await supertest(app)
+            .post(weetsPath)
+            .set(...defaultHeaders)
+            .set('authorization', token));
+        });
+
+        test('Should return a created status code', () => {
+          expect(status).toBe(201);
+        });
+
+        test('Should return the created weet info', () => {
+          const { id: weetId } = body;
+          const cleanedWeetInfo = _.omit(body, timeStamps);
+          const expectedCreatedWeet = {
+            ...weetsTestData.expectedCreatedWeet,
+            id: weetId,
+            user_id: userId
+          };
+          expect(cleanedWeetInfo).toStrictEqual(expectedCreatedWeet);
+        });
+      });
+    });
+
+    describe('Should throw the correct error if the user is not authenticated', () => {
+      beforeEach(async () => {
+        ({ body, status } = await supertest(app)
+          .post(weetsPath)
+          .set(...defaultHeaders));
+      });
+
+      test('Should return an unauthorized status', () => {
+        expect(status).toBe(401);
+      });
+
+      test('Should return the correct error', () => {
+        expect(body).toStrictEqual({ internal_code: 'unauthorized', message: 'Unauthorized' });
+      });
+    });
+
+    describe('Should throw the correct error if the user is not regular', () => {
+      let adminRoleId = 0;
+
+      beforeEach(async () => {
+        ({ id: adminRoleId } = await factory.create('role', rolesTestData.adminRole));
+        await factory.create('user', { ...usersTestData.user, roleId: adminRoleId });
+        ({
+          body: { token }
+        } = await supertest(app)
+          .post(signInPath)
+          .set(...defaultHeaders)
+          .send(usersTestData.signInRequestBody));
+
+        ({ body, status } = await supertest(app)
+          .post(weetsPath)
+          .set(...defaultHeaders)
+          .set('authorization', token));
+      });
+
+      test('Should return a forbidden status', () => {
+        expect(status).toBe(403);
+      });
+
+      test('Should return the correct error', () => {
+        expect(body).toStrictEqual({
+          internal_code: 'forbidden',
+          message: "User doesn't have permissions to execute this action"
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

enpoint POST /weets to create a weet, the created weet will be associated the signed user

## Known Issues

if a 401 status code is provided the authorization header should be set to the provided token in /users/sessions

## Trello Card

https://trello.com/c/BarjlcAT/33-crear-un-weet
