### PR TITLE
endpoint GET /weets to get paginated  weets info

### DIFF
--- a/app/controllers/weets.js
+++ b/app/controllers/weets.js
@@ -11,3 +11,13 @@ exports.createWeet = async ({ user: { id: userId } }, res, next) => {
     return next(error);
   }
 };
+
+exports.getWeets = ({ query }, res, next) =>
+  weetsService
+    .getPaginatedWeets(query)
+    .then(({ weets, count, page, size }) => {
+      const serializedWeets = weetsSerializer.serializeWeets(weets);
+
+      return res.send({ weets: serializedWeets, count, page, size });
+    })
+    .catch(next);

--- a/app/routes.js
+++ b/app/routes.js
@@ -22,4 +22,5 @@ exports.init = app => {
   app.get('/users', authUser(), validateSchema(paginationQuerySchema), usersController.getUsers);
   app.post('/admin/users', authUser([admin]), validateSchema(upsertAdminSchema), usersController.upsertAdmin);
   app.post('/weets', authUser([reg]), weetsController.createWeet);
+  app.get('/weets', authUser([reg]), validateSchema(paginationQuerySchema), weetsController.getWeets);
 };

--- a/app/serializers/weets.js
+++ b/app/serializers/weets.js
@@ -8,3 +8,5 @@ exports.serializeWeet = weet => {
     ...restWeet
   };
 };
+
+exports.serializeWeets = weets => weets.map(weet => exports.serializeWeet(weet));

--- a/app/services/weets.js
+++ b/app/services/weets.js
@@ -7,6 +7,9 @@ const {
   }
 } = require('../../config');
 const logger = require('../logger');
+const {
+  pagination: { defaultPaginationSize, defaultPage }
+} = require('../constants');
 
 exports.getExternalWeet = () =>
   httpHelper
@@ -27,3 +30,10 @@ exports.createWeet = (userId, content) =>
 
       throw databaseError('An error ocurred while trying to create weet');
     });
+
+exports.getPaginatedWeets = async ({ size = defaultPaginationSize, page = defaultPage }) => {
+  const { count, rows } = await weetModel.findAndCountAll({ limit: size, offset: page * size });
+  const weets = rows.map(weet => weet.toJSON());
+
+  return { count, size, page, weets };
+};

--- a/test/data/weets.js
+++ b/test/data/weets.js
@@ -4,3 +4,7 @@ exports.joke =
 exports.expectedCreatedWeet = {
   content: exports.joke
 };
+
+exports.weets = [...Array(5).keys()].map(index => ({ content: `test joke ${index}` }));
+
+exports.getExpectedWeetsInfo = userId => exports.weets.map(weet => ({ ...weet, user_id: userId }));

--- a/test/factory/setup.js
+++ b/test/factory/setup.js
@@ -1,6 +1,6 @@
 const { factory } = require('factory-girl');
 
-const { user: userModel, role: roleModel } = require('../../app/models');
+const { user: userModel, role: roleModel, weet: weetModel } = require('../../app/models');
 
 const firstId = 1000;
 
@@ -16,4 +16,9 @@ factory.define('role', roleModel, {
   id: factory.sequence('role.id', n => n + firstId),
   name: factory.sequence('role.name', n => `'role_${n}'`),
   code: factory.sequence('role.code', n => `'code_${n}'`)
+});
+
+factory.define('weet', weetModel, {
+  id: factory.sequence('weet.id', n => n + firstId),
+  content: factory.sequence('weet.content', n => `'joke ${n}'`)
 });

--- a/test/integration/weets/weets.test.js
+++ b/test/integration/weets/weets.test.js
@@ -12,18 +12,18 @@ jest.mock('axios');
 
 const defaultHeaders = ['Accept', 'application/json'];
 const timeStamps = ['created_at', 'updated_at'];
+const schemaErrorStatus = 422;
 
 describe('Weets test', () => {
   let body = {};
   let status = 0;
+  let token = '';
+  let regRoleId = 0;
+  let userId = 0;
+  const signInPath = '/users/sessions';
+  const weetsPath = '/weets';
 
   describe('Creates weets', () => {
-    let token = '';
-    let regRoleId = 0;
-    let userId = 0;
-    const signInPath = '/users/sessions';
-    const weetsPath = '/weets';
-
     describe('Create weets POST  /weets', () => {
       beforeEach(async () => {
         axios.get.mockImplementation(() =>
@@ -107,6 +107,100 @@ describe('Weets test', () => {
         expect(body).toStrictEqual({
           internal_code: 'forbidden',
           message: "User doesn't have permissions to execute this action"
+        });
+      });
+    });
+  });
+
+  describe('Get weets GET /weets', () => {
+    beforeEach(async () => {
+      ({ id: regRoleId } = await factory.create('role', rolesTestData.regRole));
+      ({ id: userId } = await factory.create('user', { ...usersTestData.user, roleId: regRoleId }));
+      await factory.createMany(
+        'weet',
+        weetsTestData.weets.length,
+        weetsTestData.weets.map(weet => ({ ...weet, userId }))
+      );
+      ({
+        body: { token }
+      } = await supertest(app)
+        .post(signInPath)
+        .set(...defaultHeaders)
+        .send(usersTestData.signInRequestBody));
+    });
+
+    describe('Should work correctly with satisfactory case', () => {
+      beforeEach(async () => {
+        ({ body, status } = await supertest(app)
+          .get(weetsPath)
+          .set(...defaultHeaders)
+          .set('authorization', token));
+      });
+
+      test('Should return a success status', () => {
+        expect(status).toBe(200);
+      });
+
+      test('Should return the users total', () => {
+        const { count } = body;
+        expect(count).toBe(weetsTestData.weets.length);
+      });
+
+      test('Should return the users info', () => {
+        const sortFunc = (a, b) => a.email > b.email;
+
+        const { weets } = body;
+
+        const cleanedWeets = weets.map(weet => _.omit(weet, [...timeStamps, 'id']));
+        const expectedWeetsInfo = weetsTestData.getExpectedWeetsInfo(userId).sort(sortFunc);
+
+        expect(cleanedWeets.sort(sortFunc)).toStrictEqual(expectedWeetsInfo);
+      });
+    });
+
+    describe('Should fail correctly with schema error cases', () => {
+      afterEach(() => expect(status).toBe(schemaErrorStatus));
+
+      test.each(['page', 'size'])(
+        'Should return the correct error when %s is not an integer',
+        async field => {
+          const notInteger = 2.5;
+          ({ status, body } = await supertest(app)
+            .get(weetsPath)
+            .set(...defaultHeaders)
+            .set('authorization', token)
+            .query({ [field]: notInteger }));
+
+          expect(body).toStrictEqual(
+            usersTestData.getSchemaErrorResponse([
+              {
+                location: 'query',
+                msg: 'should be integer',
+                param: field,
+                value: `${notInteger}`
+              }
+            ])
+          );
+        }
+      );
+    });
+
+    describe('Should fail correctly when the user token is not valid', () => {
+      beforeAll(async () => {
+        ({ body, status } = await supertest(app)
+          .get(weetsPath)
+          .set(...defaultHeaders)
+          .set('authorization', 'wrongToken'));
+      });
+
+      test('Should return an unauthorized status', () => {
+        expect(status).toBe(401);
+      });
+
+      test('Should return the correct error', () => {
+        expect(body).toStrictEqual({
+          internal_code: 'unauthorized',
+          message: 'An error ocurred while trying to retrieve token info'
         });
       });
     });


### PR DESCRIPTION
## Summary

endpoint GET /weets to get paginated weets information, user should be signed as regular user
## Known Issues

A regular user token should be provided to allow the user to get the weets

## Trello Card

https://trello.com/c/FyskS49E/36-obtener-weets
