### PR TITLE
Invalidate sessions

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -38,3 +38,14 @@ exports.upsertAdmin = ({ body }, res, next) =>
     .upsertAdmin(usersMapper.mapUser(body))
     .then(admin => res.send(usersSerializer.serializeUser(admin)))
     .catch(next);
+
+exports.invalidateSessions = (req, res, next) => {
+  const {
+    user: { id: userId }
+  } = req;
+
+  return usersService
+    .invalidateSessions(userId)
+    .then(() => res.send())
+    .catch(next);
+};

--- a/app/helpers/time.js
+++ b/app/helpers/time.js
@@ -1,0 +1,5 @@
+const moment = require('moment');
+
+exports.getTime = () => moment().format();
+
+exports.isGreater = (timeA, timeB) => moment(timeA).diff(moment(timeB)) >= 0;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -23,6 +23,7 @@ module.exports = (sequelize, DataTypes) => {
       lastName: { type: DataTypes.STRING, allowNull: false },
       email: { type: DataTypes.STRING, allowNull: false, unique: true },
       password: { type: DataTypes.STRING, allowNull: false },
+      tokenLimitTimestamp: { type: DataTypes.DATE },
       roleId: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,6 +19,7 @@ exports.init = app => {
   app.get('/health', healthCheck);
   app.post('/users', validateSchema(createUserSchema), usersController.createUser);
   app.post('/users/sessions', validateSchema(signInSchema), usersController.signIn);
+  app.post('/users/sessions/invalidate_all', authUser(), usersController.invalidateSessions);
   app.get('/users', authUser(), validateSchema(paginationQuerySchema), usersController.getUsers);
   app.post('/admin/users', authUser([admin]), validateSchema(upsertAdminSchema), usersController.upsertAdmin);
   app.post('/weets', authUser([reg]), weetsController.createWeet);

--- a/app/serializers/users.js
+++ b/app/serializers/users.js
@@ -1,5 +1,5 @@
 exports.serializeUser = user => {
-  const { firstName, lastName, createdAt, updatedAt, roleId, ...restUser } = user;
+  const { firstName, lastName, createdAt, updatedAt, roleId, tokenLimitTimestamp, ...restUser } = user;
   delete restUser.password;
 
   return {
@@ -8,6 +8,7 @@ exports.serializeUser = user => {
     created_at: createdAt,
     updated_at: updatedAt,
     role_id: roleId,
+    token_limit_timestamp: tokenLimitTimestamp,
     ...restUser
   };
 };

--- a/migrations/migrations/20210525040914-add-token-limit-timestamp.js
+++ b/migrations/migrations/20210525040914-add-token-limit-timestamp.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) =>
+    queryInterface.addColumn('users', 'token_limit_timestamp', {
+      allowNull: true,
+      type: Sequelize.DATE
+    }),
+
+  down: queryInterface => queryInterface.removeColumn('users', 'token_limit_timestamp')
+};

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "factory-girl": "^5.0.4",
     "jsonwebtoken": "^8.5.1",
     "jwt-simple": "^0.5.1",
+    "moment": "^2.29.1",
     "pg": "^8.6.0",
     "sequelize": "^6.6.2",
     "swagger-ui-express": "^4.0.7",

--- a/test/data/users.js
+++ b/test/data/users.js
@@ -7,7 +7,7 @@ exports.createUserRequestBody = {
   password: 'iInventedGravity'
 };
 
-exports.expectedUserInfo = _.omit(this.createUserRequestBody, 'password');
+exports.expectedUserInfo = { ..._.omit(this.createUserRequestBody, 'password'), token_limit_timestamp: null };
 
 exports.getSchemaErrorResponse = errors => ({
   internal_code: 'schema_error',
@@ -33,7 +33,8 @@ exports.getExpectedUsersInfo = roleId =>
       ..._.omit(restUser, 'password'),
       first_name: firstName,
       last_name: lastName,
-      role_id: roleId
+      role_id: roleId,
+      token_limit_timestamp: null
     };
   });
 

--- a/test/integration/users/invalidateSessions.test.js
+++ b/test/integration/users/invalidateSessions.test.js
@@ -1,0 +1,52 @@
+const supertest = require('supertest');
+const { factory } = require('factory-girl');
+
+const usersTestData = require('../../data/users');
+const rolesTestData = require('../../data/roles');
+const app = require('../../../app');
+
+describe('Invalidate sessions POST /users/sessions/invalidate_all', () => {
+  const signInPath = '/users/sessions';
+  const invalidateSessionsPath = `${signInPath}/invalidate_all`;
+  let regRoleId = 0;
+  let token = '';
+  let status = 0;
+  let body = {};
+
+  beforeEach(async () => {
+    ({ id: regRoleId } = await factory.create('role', rolesTestData.regRole));
+    await factory.create('user', { ...usersTestData.user, roleId: regRoleId });
+    ({
+      body: { token }
+    } = await supertest(app)
+      .post(signInPath)
+      .send(usersTestData.signInRequestBody));
+
+    ({ status } = await supertest(app)
+      .post(invalidateSessionsPath)
+      .set('authorization', token));
+  });
+
+  test('Should return a success status', () => {
+    expect(status).toBe(200);
+  });
+
+  describe('Should not allow authentication with expired tokens', () => {
+    beforeEach(async () => {
+      ({ status, body } = await supertest(app)
+        .post(invalidateSessionsPath)
+        .set('authorization', token));
+    });
+
+    test('Should return an unauthorized status', () => {
+      expect(status).toBe(401);
+    });
+
+    test('Should return the correct error', () => {
+      expect(body).toStrictEqual({
+        internal_code: 'unauthorized',
+        message: 'This token already expired'
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

endpoins POST /users/sessions/invalidate_all to invalidate existing sessions. when the endpoint is consumed a timestamp limit is stored in the user model. when the token is validated, the token timestamp is compared with the limit timestamp in order to decide if the token is expired

## Known Issues

N/A

## Trello Card

https://trello.com/c/MMNUfyiA/24-deshabilitar-todas-las-sesiones
